### PR TITLE
Revert "Fix out of date deps"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Click here to send a test email
 ```
 
 Click the link provided to send a test email to be intercepted by a local instance of MailCatcher. Mail is 
-processed by msmtp - you can reconfigure it to mail to an external SMTP server instead, if desired.
+processed by ssmtp - you can reconfigure it to mail to an external SMTP server instead, if desired.
 
 To stop containers, just press Ctrl-C in the terminal.
 

--- a/docker/dockerfiles/Dockerfile.php56.web
+++ b/docker/dockerfiles/Dockerfile.php56.web
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
                 libfreetype6-dev \
                 libpng-dev \
                 libmcrypt-dev \
-                mariadb-client \
+                mysql-client \
                 vim \
                 nano \
                 git \
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
                 libxml2-dev \
                 sudo \
                 wget \
-                msmtp \
+                ssmtp \
         && docker-php-ext-install gd iconv mcrypt pdo pdo_mysql mysql mysqli mbstring zip
 
 RUN pecl install xdebug-2.5.5
@@ -28,7 +28,7 @@ ARG DOCKER_HOST_PLATFORM
 
 COPY ./files/php/platform/*-${DOCKER_HOST_PLATFORM}.ini /usr/local/etc/php/conf.d/
 
-COPY ./files/msmtp/msmtp.conf /etc/msmtp/
+COPY ./files/ssmtp/ssmtp.conf /etc/ssmtp/
 
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions -name 'xdebug.so')" \
         >> /usr/local/etc/php/conf.d/ext-xdebug.ini

--- a/docker/dockerfiles/Dockerfile.php70.web
+++ b/docker/dockerfiles/Dockerfile.php70.web
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
                 libfreetype6-dev \
                 libpng-dev \
                 libmcrypt-dev \
-                mariadb-client \
+                mysql-client \
                 vim \
                 nano \
                 git \
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
                 libxml2-dev \
                 sudo \
                 wget \
-                msmtp \
+                ssmtp \
         && docker-php-ext-install gd iconv mcrypt pdo pdo_mysql mysqli mbstring zip
 
 RUN pecl install xdebug
@@ -28,7 +28,7 @@ ARG DOCKER_HOST_PLATFORM
 
 COPY ./files/php/platform/*-${DOCKER_HOST_PLATFORM}.ini /usr/local/etc/php/conf.d/
 
-COPY ./files/msmtp/msmtp.conf /etc/msmtp/
+COPY ./files/ssmtp/ssmtp.conf /etc/ssmtp/
 
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions -name 'xdebug.so')" \
         >> /usr/local/etc/php/conf.d/ext-xdebug.ini

--- a/docker/dockerfiles/Dockerfile.php71.web
+++ b/docker/dockerfiles/Dockerfile.php71.web
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
                 libfreetype6-dev \
                 libpng-dev \
                 libmcrypt-dev \
-                mariadb-client \
+                mysql-client \
                 vim \
                 nano \
                 git \
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
                 libxml2-dev \
                 sudo \
                 wget \
-                msmtp \
+                ssmtp \
         && docker-php-ext-install gd iconv mcrypt pdo pdo_mysql mysqli mbstring zip
 
 RUN pecl install xdebug
@@ -28,7 +28,7 @@ ARG DOCKER_HOST_PLATFORM
 
 COPY ./files/php/platform/*-${DOCKER_HOST_PLATFORM}.ini /usr/local/etc/php/conf.d/
 
-COPY ./files/msmtp/msmtp.conf /etc/msmtp/
+COPY ./files/ssmtp/ssmtp.conf /etc/ssmtp/
 
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions -name 'xdebug.so')" \
         >> /usr/local/etc/php/conf.d/ext-xdebug.ini

--- a/docker/dockerfiles/Dockerfile.php72.web
+++ b/docker/dockerfiles/Dockerfile.php72.web
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
                 libfreetype6-dev \
                 libpng-dev \
                 libmcrypt-dev \
-                mariadb-client \
+                mysql-client \
                 vim \
                 nano \
                 git \
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
                 libxml2-dev \
                 sudo \
                 wget \
-                msmtp \
+                ssmtp \
         && docker-php-ext-install gd iconv pdo pdo_mysql mysqli mbstring zip
 
 RUN pecl install xdebug
@@ -28,7 +28,7 @@ ARG DOCKER_HOST_PLATFORM
 
 COPY ./files/php/platform/*-${DOCKER_HOST_PLATFORM}.ini /usr/local/etc/php/conf.d/
 
-COPY ./files/msmtp/msmtp.conf /etc/msmtp/
+COPY ./files/ssmtp/ssmtp.conf /etc/ssmtp/
 
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions -name 'xdebug.so')" \
         >> /usr/local/etc/php/conf.d/ext-xdebug.ini

--- a/docker/dockerfiles/Dockerfile.php73.web
+++ b/docker/dockerfiles/Dockerfile.php73.web
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
                 libfreetype6-dev \
                 libpng-dev \
                 libmcrypt-dev \
-                mariadb-client \
+                mysql-client \
                 vim \
                 nano \
                 git \
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
                 libxml2-dev \
                 sudo \
                 wget \
-                msmtp \
+                ssmtp \
 		libzip-dev \
         && docker-php-ext-install gd iconv pdo pdo_mysql mysqli mbstring zip
 
@@ -29,7 +29,7 @@ ARG DOCKER_HOST_PLATFORM
 
 COPY ./files/php/platform/*-${DOCKER_HOST_PLATFORM}.ini /usr/local/etc/php/conf.d/
 
-COPY ./files/msmtp/msmtp.conf /etc/msmtp/
+COPY ./files/ssmtp/ssmtp.conf /etc/ssmtp/
 
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions -name 'xdebug.so')" \
         >> /usr/local/etc/php/conf.d/ext-xdebug.ini

--- a/docker/files/php/mail.ini
+++ b/docker/files/php/mail.ini
@@ -1,2 +1,2 @@
-sendmail_path = "/usr/sbin/msmtp -t"
+sendmail_path = "/usr/sbin/ssmtp -t"
 sendmail_from = "do-not-reply@qa.yourdomain.com"


### PR DESCRIPTION
Reverts arkamax2k/docker-php-dev#1

@matchett808-gh , I'm reverting this since it seems to break mail subsystem. For one, the msmtp package needs configuration files renamed, and the binary is in /usr/bin/msmtp - I did all that, but it won't pick the configuration files. Please kindly update your changes with a working configuration set and I will be happy to review this again. Sorry, and thanks again for your contribution! 